### PR TITLE
Fix tables with empty first cell

### DIFF
--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -693,7 +693,7 @@ class HTML2Text(html.parser.HTMLParser):
                             self.o("</" + config.TABLE_MARKER_FOR_PAD + ">")
                             self.o("  \n")
                 if tag in ["td", "th"] and start:
-                    if self.split_next_td:
+                    if self.split_next_td or self.table_start:
                         self.o("| ")
                     self.split_next_td = True
 


### PR DESCRIPTION
If the first cell of a table is empty, no entry was created for in in the markdown table. This resulted in markdown tables which do parse properly.